### PR TITLE
Added the default subtitle feature

### DIFF
--- a/Crunchyroll-Downloader/Program.cs
+++ b/Crunchyroll-Downloader/Program.cs
@@ -33,16 +33,16 @@ namespace CrunchyrollDownloader
                 if (STState == "1")
                 {
                     if (Quality == "best")
-                        process.StartInfo.Arguments = $"--write-sub --sub-lang {Langue} --sub-format {Format} -f best --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
+                        process.StartInfo.Arguments = $"--write-sub --sub-lang {Langue} --sub-format {Format} -f best --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --postprocessor-args "-disposition:s:0 default" --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
                     else
-                        process.StartInfo.Arguments = $"--write-sub --sub-lang {Langue} --sub-format {Format} -f \"best[height={Quality}]\" --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
+                        process.StartInfo.Arguments = $"--write-sub --sub-lang {Langue} --sub-format {Format} -f \"best[height={Quality}]\" --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --postprocessor-args "-disposition:s:0 default" --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
                 }
                 else
                 {
                     if (Quality == "best")
-                        process.StartInfo.Arguments = $"-f best --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
+                        process.StartInfo.Arguments = $"-f best --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --postprocessor-args "-disposition:s:0 default" --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
                     else
-                        process.StartInfo.Arguments = $"-f \"best[height={Quality}]\" --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
+                        process.StartInfo.Arguments = $"-f \"best[height={Quality}]\" --no-part -o \"{SavePath}\" --recode-video mkv --embed-subs --postprocessor-args "-disposition:s:0 default" --cookies C:\\ProgramData\\Crunchy-DL\\cookies.txt {Url}";
                 }
             }
             else


### PR DESCRIPTION
--postprocessor-args "-disposition:s:0 default"

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
When you use .mkv and VLC, VLC now automatically chooses the subtitle without any changes to VLC-Config.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change is required for simplicity.
Fixes #10.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I opened the project in Visual Studio 2017 and build it.
Then i checked it with MediaInfo and it changed the value from "No" to "Yes" at "Default".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
