### PR TITLE
Added new method to remove downloaded zips

### DIFF
--- a/Crunchyroll-Downloader/MainWindow.xaml.cs
+++ b/Crunchyroll-Downloader/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace CrunchyrollDownloader
 		public MainWindow()
 		{
 			var actualFolder = @"C:\ProgramData\Crunchy-DL";
+			RemoveZips(actualFolder);
 			using (var client = new WebClient())
 			{
 				var zip = new FastZip();
@@ -97,7 +98,18 @@ namespace CrunchyrollDownloader
 		}
 
 		public string dl_label { get; private set; }
-
+		private void RemoveZips(string actualFolder)
+		{
+			var ffmpeg = actualFolder + @"\ffmpeg.zip";
+			var ffplay = actualFolder + @"\ffplay.zip";
+			var ffprobe = actualFolder + @"\ffprobe.zip";
+			if (File.Exists(ffmpeg))
+				File.Delete(ffmpeg);
+			if (File.Exists(ffplay))
+				File.Delete(ffplay);
+			if (File.Exists(ffprobe))
+				File.Delete(ffprobe);
+		}
 		private void InstallAll()
 		{
 			var viewerThread = new Thread(() =>
@@ -139,6 +151,7 @@ namespace CrunchyrollDownloader
 				zip.ExtractZip(actualFolder + @"\ffplay.zip", actualFolder, "");
 				zip.ExtractZip(actualFolder + @"\ffprobe.zip", actualFolder, "");
 				viewerThread.Abort();
+				RemoveZips(actualFolder);
 				MessageBox.Show("youtube-dl and FFmpeg are now installed.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
 				InitializeComponent();
 				CheckCookie();


### PR DESCRIPTION
<!--- PLEASE, do a pull request ONLY on develop branch -->
<!--- Provide a general summary of your changes in the Title above -->
I added new method to remove downloaded zips using File.Delete.
I have **not** modified the dotnet version. Sorry about that. I didn't read the dialog that popped up from Visual Studio and just clicked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This saves space on the client machine.
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
Run in Visual Studio.

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/22552895/48818184-e30e1780-ecfe-11e8-9413-533d552e966a.png)
After:
![image](https://user-images.githubusercontent.com/22552895/48818196-f28d6080-ecfe-11e8-85b0-41a71edf3d8f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
